### PR TITLE
CampaignExtention solution, RolesApi class added.

### DIFF
--- a/source/Sitecore.Salesforce.CampaignExtention.sln
+++ b/source/Sitecore.Salesforce.CampaignExtention.sln
@@ -1,0 +1,20 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sitecore.Salesforce.CampaignExtention", "Sitecore.Salesforce.CampaignExtention\Sitecore.Salesforce.CampaignExtention.csproj", "{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/source/Sitecore.Salesforce.CampaignExtention/Properties/AssemblyInfo.cs
+++ b/source/Sitecore.Salesforce.CampaignExtention/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("Sitecore.Salesforce.CampaignExtention")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("Sitecore.Salesforce.CampaignExtention")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("b4e9980a-529a-430b-acaf-a3526ee06bcc")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/Sitecore.Salesforce.CampaignExtention/RolesApi.cs
+++ b/source/Sitecore.Salesforce.CampaignExtention/RolesApi.cs
@@ -1,0 +1,177 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json.Linq;
+using Sitecore.Diagnostics;
+using Sitecore.Salesforce.Api;
+using Sitecore.Salesforce.Client;
+using Sitecore.Salesforce.Client.Data;
+using Sitecore.Salesforce.Configuration;
+using Sitecore.Salesforce.Data;
+using Sitecore.Salesforce.Soql;
+
+namespace Sitecore.Salesforce.CampaignExtention.Api
+{
+  public class RolesApi : IRolesApi //Sitecore.Salesforce.Api.IRolesApi
+  {
+    public string ContactObjectName { get; set; }
+
+    public string RoleAssociationObjectName { get; set; }
+
+    public string RoleObjectName { get; set; }
+
+    public string RoleFieldName { get; set; }
+
+    protected readonly ISalesforceFieldMapping FieldMapping;
+
+    protected readonly ISalesforceClient Client;
+
+    public RolesApi(ISalesforceClient client, ISalesforceFieldMapping fieldMapping)
+    {
+      Assert.ArgumentNotNull(client, "client");
+
+      this.Client = client;
+      this.FieldMapping = fieldMapping;
+    }
+
+    public virtual List<SalesforceRole> GetAllRoles()
+    {
+      var query = string.Format("SELECT Id, {0} FROM {1}", this.RoleFieldName, this.RoleObjectName);
+
+      return new List<SalesforceRole>(this.Client.QueryAll<SalesforceRole>(query));
+    }
+
+    public virtual List<SalesforceRole> GetRolesForUser(string loginName)
+    {
+      Assert.ArgumentNotNullOrEmpty(loginName, "loginName");
+
+      var query = string.Format(
+          "SELECT Id, {0} FROM {1} WHERE Id IN (SELECT CampaignId FROM {2} WHERE {3}.{4} {5})",
+        this.RoleFieldName,
+        this.RoleObjectName,
+        this.RoleAssociationObjectName,
+        this.ContactObjectName,
+        this.FieldMapping.Login,
+        ComparisonOperatorParser.Parse(ComparisonOperator.Equals, loginName));
+
+      return this.Client.QueryAll<SalesforceRole>(query).ToList();
+    }
+
+    public virtual SalesforceRole Get(string roleName)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleName, "roleName");
+
+      var query = string.Format("SELECT Id, {0} FROM {1} WHERE {0} {2}"
+          ,this.RoleFieldName
+          ,this.RoleObjectName
+          ,ComparisonOperatorParser.Parse(ComparisonOperator.Equals, roleName));
+
+      return this.Client.QueryAll<SalesforceRole>(query).FirstOrDefault();
+    }
+
+    public virtual List<string> GetUsersInRole(string roleName)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleName, "roleName");
+      
+      var query = string.Format(
+        "SELECT {1}.{0} FROM {1} WHERE Id IN (SELECT ContactId FROM {2} WHERE {3}.{4} {5})",
+        this.FieldMapping.Login,
+        this.ContactObjectName,
+        this.RoleAssociationObjectName,
+        this.RoleObjectName,
+        this.RoleFieldName,
+        ComparisonOperatorParser.Parse(ComparisonOperator.Equals, roleName));
+
+      return this.GetUsersByQuery(query);
+    }
+
+    public virtual List<string> FindUsersInRole(string roleName, string usernameToMatch)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleName, "roleName");
+      Assert.ArgumentNotNullOrEmpty(usernameToMatch, "usernameToMatch");
+
+      var query = string.Format("SELECT {1} FROM {2} WHERE {0}.{1} like '%{5}%' and {3}.{6} = '{4}'",
+      this.ContactObjectName,
+      this.FieldMapping.Login,
+      this.RoleAssociationObjectName,
+      this.RoleObjectName,
+           roleName,
+           usernameToMatch,
+      this.RoleFieldName);
+
+      return this.GetUsersByQuery(query);
+    }
+
+    public virtual OperationResult Create(string roleName)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleName, "roleName");
+
+      var result = this.Client.HttpPost<OperationResult>(
+        string.Format("sobjects/{0}", this.RoleObjectName),
+        new Dictionary<string, string> { { "Name", roleName }, { "IsActive", "true" } });
+
+      return result;
+    }
+
+    public virtual bool DeleteById(string roleId)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleId, "roleId");
+
+      return this.Client.HttpDelete(string.Format("sobjects/{0}/{1}", this.RoleObjectName, roleId));
+    }
+
+    public virtual OperationResult AddUserToRole(string roleId, string userId)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleId, "roleId");
+      Assert.ArgumentNotNullOrEmpty(userId, "userId");
+
+      var data = new Dictionary<string, string>()
+              {
+                { string.Format("{0}Id", this.RoleObjectName), roleId },
+                { string.Format("{0}Id", this.ContactObjectName), userId },
+                { "Status", "Sent" }
+              };
+      
+      return this.Client.HttpPost<OperationResult>(string.Format("sobjects/{0}", this.RoleAssociationObjectName), data);
+    }
+
+    public virtual bool DeleteUserFromRole(string roleName, string loginName)
+    {
+      Assert.ArgumentNotNullOrEmpty(roleName, "roleName");
+      Assert.ArgumentNotNullOrEmpty(loginName, "loginName");
+
+      var query = string.Format("SELECT Id FROM {2} WHERE {0}.{1} {3} and {4}.{5} {6}",
+      this.ContactObjectName,
+      this.FieldMapping.Login,
+      this.RoleAssociationObjectName,
+      ComparisonOperatorParser.Parse(ComparisonOperator.Equals, loginName),
+      this.RoleObjectName,
+      this.RoleFieldName,
+      ComparisonOperatorParser.Parse(ComparisonOperator.Equals, roleName)
+      );
+
+      var roleAssociation = this.Client.QueryAll<RoleAssociation>(query).FirstOrDefault();
+
+      if (roleAssociation != null)
+      {
+        return this.Client.HttpDelete(string.Format("sobjects/{0}/{1}", this.RoleAssociationObjectName, roleAssociation.Id));
+      }
+
+      return false;
+    }
+
+    protected virtual List<string> GetUsersByQuery(string query)
+    {
+      Assert.ArgumentNotNullOrEmpty(query, "query");
+
+      var result = this.Client.QueryAll<JToken>(query);
+
+      ISet<string> users = new HashSet<string>();
+
+      foreach (JToken token in result)
+      {
+        users.Add(token.Value<string>(this.FieldMapping.Login));
+      }
+      return new List<string>(users);
+    }
+  }
+}

--- a/source/Sitecore.Salesforce.CampaignExtention/Sitecore.Salesforce.CampaignExtention.csproj
+++ b/source/Sitecore.Salesforce.CampaignExtention/Sitecore.Salesforce.CampaignExtention.csproj
@@ -1,0 +1,83 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{9DB5C4A4-04EB-40D7-8072-F5264B5665CB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Sitecore.Salesforce.CampaignExtention</RootNamespace>
+    <AssemblyName>Sitecore.Salesforce.CampaignExtention</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <UseVSHostingProcess>true</UseVSHostingProcess>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\Website\bin\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="Sitecore.Client">
+      <HintPath>..\Website\bin\Sitecore.Client.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Sitecore.Kernel">
+      <HintPath>..\Website\bin\Sitecore.Kernel.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Sitecore.Salesforce">
+      <HintPath>..\Website\bin\Sitecore.Salesforce.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Sitecore.Salesforce.Client">
+      <HintPath>..\Website\bin\Sitecore.Salesforce.Client.dll</HintPath>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Web" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.Services" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="RolesApi.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Sitecore.Salesforce.RoleCampaign.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PostBuildEvent>xcopy "$(TargetDir)*.dll" "$(ProjectDir)\..\Website\bin" /S /F /R /Y /I</PostBuildEvent>
+  </PropertyGroup>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/Sitecore.Salesforce.CampaignExtention/Sitecore.Salesforce.RoleCampaign.config
+++ b/source/Sitecore.Salesforce.CampaignExtention/Sitecore.Salesforce.RoleCampaign.config
@@ -1,0 +1,20 @@
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/">
+	<sitecore>
+		<salesforce>
+	        <configurations>
+				<configuration type="Sitecore.Salesforce.Configuration.SalesforceConfiguration, Sitecore.Salesforce">
+					<api>
+						<rolesApi patch:instead="*[@type='Sitecore.Salesforce.Api.RolesApi, Sitecore.Salesforce']" type="Sitecore.Salesforce.CampaignExtention.Api.RolesApi, Sitecore.Salesforce.CampaignExtention">
+						  <param desc="client" ref="salesforce/configurations/*[@provider='$(provider)'][1]/client"/>
+						  <param desc="fieldMapping" ref="salesforce/configurations/*[@provider='$(provider)'][1]/fieldMapping"/>
+						  <roleObjectName>Campaign</roleObjectName>
+						  <roleAssociationObjectName>CampaignMember</roleAssociationObjectName>
+						  <contactObjectName>Contact</contactObjectName>
+						  <roleFieldName>Name</roleFieldName>
+						</rolesApi>
+					</api>
+				</configuration>
+			</configurations>
+		</salesforce>
+	</sitecore>
+</configuration>


### PR DESCRIPTION
Here is a small class, that implements Salesforce roles Api (Sitecore.Salesforce.Api.IRolesApi).
The purpose is to use standard Salesforce Campaigns instead of custom Roles table.
