### PR TITLE
error with salesforce authentication

### DIFF
--- a/source/Sitecore.Salesforce.Client/Security/AuthenticatorBase.cs
+++ b/source/Sitecore.Salesforce.Client/Security/AuthenticatorBase.cs
@@ -10,8 +10,9 @@
 
   using Sitecore.Salesforce.Client.Data.Errors;
   using Sitecore.Salesforce.Client.Exceptions;
+  using System.Net;
 
-  public abstract class AuthenticatorBase : ClientBase, IAuthenticator
+    public abstract class AuthenticatorBase : ClientBase, IAuthenticator
   {
     private string tokenRequestUri;
 
@@ -47,6 +48,8 @@
 
     public virtual async Task<IAuthToken> AuthenticateAsync()
     {
+      ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
       HttpContent content = new FormUrlEncodedContent(this.GetAuthParameters());
       
       var request = new HttpRequestMessage


### PR DESCRIPTION
Starting from June 2016 Salesforce will is disabling TLS 1.0 encryption accross its whole platform in a phased approach
http://stackoverflow.com/questions/38647591/error-with-salesforce-authentication-from-c-sharp-clients

I haven't updated the Sitecore Module Package. It looks like a publish profile is missing which may have been used to generate the dll versions